### PR TITLE
Implemented Datetime Functions.

### DIFF
--- a/src/lib/abstract_expression.hpp
+++ b/src/lib/abstract_expression.hpp
@@ -67,6 +67,10 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
       AggregateFunction aggregate_function, const std::vector<std::shared_ptr<DerivedExpression>>& function_arguments,
       const std::optional<std::string>& alias = std::nullopt);
 
+  static std::shared_ptr<DerivedExpression> create_datetime_function(
+      DatetimeFunction datetime_function, const std::vector<std::shared_ptr<DerivedExpression>>& function_arguments,
+      const std::optional<std::string>& alias = std::nullopt);
+
   static std::shared_ptr<DerivedExpression> create_binary_operator(
       ExpressionType type, const std::shared_ptr<DerivedExpression>& left,
       const std::shared_ptr<DerivedExpression>& right, const std::optional<std::string>& alias = std::nullopt);
@@ -131,6 +135,7 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
    * Getters. Only call them if you are sure the type() has such a member
    */
   AggregateFunction aggregate_function() const;
+  DatetimeFunction datetime_function() const;
   const AllTypeVariant value() const;
   const std::vector<std::shared_ptr<DerivedExpression>>& aggregate_function_arguments() const;
   ValuePlaceholder value_placeholder() const;
@@ -167,6 +172,7 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
   std::optional<AllTypeVariant> _value;
 
   std::optional<AggregateFunction> _aggregate_function;
+  std::optional<DatetimeFunction> _datetime_function;
 
   /*
    * A list of Expressions used in FunctionIdentifiers and CASE Expressions.

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -40,6 +40,7 @@ const std::unordered_map<ExpressionType, std::string> expression_type_to_string 
     {ExpressionType::Placeholder, "Parameter"},
     {ExpressionType::Column, "Column"},
     {ExpressionType::Function, "Function"},
+    {ExpressionType::DatetimeFunction, "DateimeFunction"},
     {ExpressionType::Select, "Select"},
     /*Arithmetic operators*/
     {ExpressionType::Addition, "Addition"},
@@ -129,6 +130,13 @@ const boost::bimap<AggregateFunction, std::string> aggregate_function_to_string 
         {AggregateFunction::Avg, "AVG"},
         {AggregateFunction::Count, "COUNT"},
         {AggregateFunction::CountDistinct, "COUNT DISTINCT"},
+    });
+
+const boost::bimap<DatetimeFunction, std::string> datetime_function_to_string =
+    make_bimap<DatetimeFunction, std::string>({
+        {DatetimeFunction::Year, "YEAR"},
+        {DatetimeFunction::Month, "MONTH"},
+        {DatetimeFunction::Day, "DAY"},
     });
 
 const boost::bimap<DataType, std::string> data_type_to_string =

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -137,6 +137,9 @@ const boost::bimap<DatetimeFunction, std::string> datetime_function_to_string =
         {DatetimeFunction::Year, "YEAR"},
         {DatetimeFunction::Month, "MONTH"},
         {DatetimeFunction::Day, "DAY"},
+        {DatetimeFunction::Hour, "HOUR"},
+        {DatetimeFunction::Minute, "MINUTE"},
+        {DatetimeFunction::Second, "SECOND"},
     });
 
 const boost::bimap<DataType, std::string> data_type_to_string =

--- a/src/lib/constant_mappings.hpp
+++ b/src/lib/constant_mappings.hpp
@@ -19,6 +19,7 @@ extern const std::unordered_map<ExpressionType, std::string> expression_type_to_
 extern const std::unordered_map<JoinMode, std::string> join_mode_to_string;
 extern const std::unordered_map<UnionMode, std::string> union_mode_to_string;
 extern const boost::bimap<AggregateFunction, std::string> aggregate_function_to_string;
+extern const boost::bimap<DatetimeFunction, std::string> datetime_function_to_string;
 extern const boost::bimap<DataType, std::string> data_type_to_string;
 
 }  // namespace opossum

--- a/src/lib/import_export/csv_converter.hpp
+++ b/src/lib/import_export/csv_converter.hpp
@@ -108,10 +108,15 @@ inline std::function<int(const std::string&)> CsvConverter<int>::_get_conversion
 template <>
 inline std::function<int64_t(const std::string&)> CsvConverter<int64_t>::_get_conversion_function() {
   return [](const std::string& str) {
-    size_t pos;
-    auto converted = static_cast<int64_t>(std::stoll(str, &pos));
-    Assert(pos == str.size(), "Unprocessed characters found while converting to long: " + str);
-    return converted;
+    struct tm tm;
+    if(strptime(str.c_str(), "%Y-%m-%d %H:%M:%S", &tm) == NULL) {
+      size_t pos;
+      auto converted = static_cast<int64_t>(std::stoll(str, &pos));
+      Assert(pos == str.size(), "Unprocessed characters found while converting to long: " + str);
+      return converted;
+    } else {
+      return static_cast<int64_t>(mktime(&tm));
+    }
   };
 }
 

--- a/src/lib/operators/pqp_expression.cpp
+++ b/src/lib/operators/pqp_expression.cpp
@@ -26,6 +26,7 @@ PQPExpression::PQPExpression(const std::shared_ptr<LQPExpression>& lqp_expressio
 
   _value = lqp_expression->_value;
   _aggregate_function = lqp_expression->_aggregate_function;
+  _datetime_function = lqp_expression->_datetime_function;
   _table_name = lqp_expression->_table_name;
   _value_placeholder = lqp_expression->_value_placeholder;
 

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -214,6 +214,15 @@ const pmr_concurrent_vector<std::optional<T>> Projection::_evaluate_expression(
         case DatetimeFunction::Day:
           op = [](const struct tm& tm) -> int64_t { return tm.tm_mday;};
           break;
+        case DatetimeFunction::Hour:
+          op = [](const struct tm& tm) -> int64_t { return tm.tm_hour;};
+          break;
+        case DatetimeFunction::Minute:
+          op = [](const struct tm& tm) -> int64_t { return tm.tm_min;};
+          break;
+        case DatetimeFunction::Second:
+          op = [](const struct tm& tm) -> int64_t { return tm.tm_sec;};
+          break;
         default:
           Fail("Unknown DatetimeFunction");
       }

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -91,7 +91,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       name = *column_expression->alias();
     } else if (column_expression->type() == ExpressionType::Column) {
       name = _input_table_left()->column_name(column_expression->column_id());
-    } else if (column_expression->is_arithmetic_operator() || column_expression->type() == ExpressionType::Literal) {
+    } else if (column_expression->is_arithmetic_operator() || column_expression->type() == ExpressionType::Literal || column_expression->type() == ExpressionType::DatetimeFunction) {
       name = column_expression->to_string(_input_table_left()->column_names());
     } else {
       Fail("Expression type is not supported.");
@@ -134,6 +134,9 @@ DataType Projection::_get_type_of_expression(const std::shared_ptr<PQPExpression
   }
   if (expression->type() == ExpressionType::Column) {
     return table->column_type(expression->column_id());
+  }
+  if (expression->type() == ExpressionType::DatetimeFunction) {
+    return DataType::Long;
   }
 
   Assert(expression->is_arithmetic_operator(),
@@ -192,12 +195,50 @@ const pmr_concurrent_vector<std::optional<T>> Projection::_evaluate_expression(
   /**
    * Handle arithmetic expression
    */
-  Assert(expression->is_arithmetic_operator(), "Projection only supports literals, column refs and arithmetics");
-
-  const auto& arithmetic_operator_function = _get_operator_function<T>(expression->type());
+  Assert(expression->is_arithmetic_operator() || expression->type() == ExpressionType::DatetimeFunction, "Projection only supports literals, column refs and arithmetics");
 
   pmr_concurrent_vector<std::optional<T>> values;
   values.resize(table->get_chunk(chunk_id)->size());
+
+  //datetimes are int
+  if (expression->type() == ExpressionType::DatetimeFunction) {
+    if constexpr(std::is_same_v<T, int64_t>) {
+      std::function<int64_t(const struct tm&)> op;
+      switch (expression->datetime_function()) {
+        case DatetimeFunction::Year:
+          op = [](const struct tm& tm) -> int64_t { return tm.tm_year + 1900;};
+          break;
+        case DatetimeFunction::Month:
+          op = [](const struct tm& tm) -> int64_t { return tm.tm_mon + 1;};
+          break;
+        case DatetimeFunction::Day:
+          op = [](const struct tm& tm) -> int64_t { return tm.tm_mday;};
+          break;
+        default:
+          Fail("Unknown DatetimeFunction");
+      }
+
+      auto func = [&](std::optional<T> time) -> std::optional<T> {
+        if (!time) return std::nullopt;
+        time_t t = time.value();
+        struct tm* tm = localtime(&t);
+        return op(*tm);
+      };
+
+      Assert(expression->aggregate_function_arguments().size() == 1, "Too many arguments.");
+      const auto& expr = expression->aggregate_function_arguments().at(0);
+      const auto left_values = _evaluate_expression<int64_t>(expr, table, chunk_id);
+      // auto func = [&](std::optional<T> left_value) -> std::optional<T> {
+      // if (!left_value) return std::nullopt;
+      // return arithmetic_operator_function(*left_value, right_value);
+      std::transform(left_values.begin(), left_values.end(), values.begin(), func);
+      return values;
+    } else {
+      Fail("Called datetime function on invalid column type.");
+    }
+  }
+
+  const auto& arithmetic_operator_function = _get_operator_function<T>(expression->type());
 
   const auto& left = expression->left_child();
   const auto& right = expression->right_child();

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -272,15 +272,15 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_select(const hsql::Se
   // because all elements must either be aggregate functions or columns of the GROUP BY clause,
   // so the Aggregate operator will handle them.
   auto is_aggregate = select.groupBy != nullptr;
-  if (!is_aggregate) {
-    for (auto* expr : *select.selectList) {
-      // TODO(anybody): Only consider aggregate functions here (i.e., SUM, COUNT, etc. - but not CONCAT, ...).
-      if (expr->isType(hsql::kExprFunctionRef)) {
-        is_aggregate = true;
-        break;
-      }
-    }
-  }
+  // if (!is_aggregate) {
+  //   for (auto* expr : *select.selectList) {
+  //     // TODO(anybody): Only consider aggregate functions here (i.e., SUM, COUNT, etc. - but not CONCAT, ...).
+  //     if (expr->isType(hsql::kExprFunctionRef)) {
+  //       is_aggregate = true;
+  //       break;
+  //     }
+  //   }
+  // }
 
   if (is_aggregate) {
     current_result_node = _translate_aggregate(select, current_result_node);
@@ -741,7 +741,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_projection(
     const auto expr = HSQLExprTranslator::to_lqp_expression(*select_column_hsql_expr, input_node);
 
     DebugAssert(expr->type() == ExpressionType::Star || expr->type() == ExpressionType::Column ||
-                    expr->is_arithmetic_operator() || expr->type() == ExpressionType::Literal,
+                    expr->is_arithmetic_operator() || expr->type() == ExpressionType::Literal ||
+                    expr->type()  == ExpressionType::DatetimeFunction,
                 "Only column references, star-selects, and arithmetic expressions supported for now.");
 
     if (expr->type() == ExpressionType::Star) {

--- a/src/lib/type_cast.hpp
+++ b/src/lib/type_cast.hpp
@@ -50,7 +50,13 @@ std::enable_if_t<std::is_integral<T>::value, T> type_cast(const AllTypeVariant& 
   try {
     return boost::lexical_cast<T>(value);
   } catch (...) {
-    return boost::numeric_cast<T>(boost::lexical_cast<double>(value));
+    auto s = type_cast<std::string>(value);
+    struct tm tm;
+    if(strptime(s.c_str(), "%Y-%m-%d %H:%M:%S", &tm) == NULL) {
+      return boost::numeric_cast<T>(boost::lexical_cast<double>(value));
+    } else {
+      return static_cast<T>(mktime(&tm));
+    }
   }
 }
 

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -189,6 +189,7 @@ enum class ExpressionType {
   Column,
   /*An identifier for a function, such as COUNT, MIN, MAX*/
   Function,
+  DatetimeFunction,
 
   /*A subselect*/
   Select,
@@ -230,6 +231,8 @@ enum class JoinMode { Inner, Left, Right, Outer, Cross, Natural, Self, Semi, Ant
 enum class UnionMode { Positions };
 
 enum class AggregateFunction { Min, Max, Sum, Avg, Count, CountDistinct };
+
+enum class DatetimeFunction { Year, Month, Day };
 
 enum class OrderByMode { Ascending, Descending, AscendingNullsLast, DescendingNullsLast };
 

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -232,7 +232,7 @@ enum class UnionMode { Positions };
 
 enum class AggregateFunction { Min, Max, Sum, Avg, Count, CountDistinct };
 
-enum class DatetimeFunction { Year, Month, Day };
+enum class DatetimeFunction { Year, Month, Day, Hour, Minute, Second };
 
 enum class OrderByMode { Ascending, Descending, AscendingNullsLast, DescendingNullsLast };
 


### PR DESCRIPTION

# Problem Description

Currently, hyrise does not support for date/time datatypes and functions implemented on them. The goal of this PR is add support for these functions:

```sql
SELECT YEAR(some_date) FROM some_table;
```

See **Discussion** below, for limitations of this PR.

# Implementation

For now, hyrise only supports aggregate functions in queries. Worse, in some parts of the codebase every function is considered an aggregate function. ([Example](https://github.com/krichly/hyrise/pull/1/files#diff-31d486bc00c6cd0d8c24dfd82aed3938L278))

Thus, we have to add support for functions in the immediate representations PQP and LQP.

```text
    [SQL-AST] -> [LQP Node] -> [PQP Node]
```

Both IRs share an `AbstractExpression` superclass, which handles most of the behaviour of expressions (see below).

## SQL-AST to LQP

`HSQLExprTranslator::to_lqp_expression` converts an expression node provided by the SQL Parser to LQP IR. `hsql::kExprFunctionRef` refers to the original AST node and was converted into an aggregate function expression. This is done by searching the function name in a map of aggregate function names:

```Python
# pseudocode
name_to_variant = {
    "MIN": AggregateFunction::Min,
    "MAX": AggregateFunction::Max,
    "SUM": AggregateFunction::Sum,
    "AVG": AggregateFunction::Avg,
    "COUNT": AggregateFunction::Count,
    "COUNT DISTINCT": AggregateFunction::CountDistinct,
}

if not func.name in name_to_variant:
    Fail(...)
else:
    agg_fn = name_to_variant[func.name]
    node = LQPExpression::create_aggregate_function(agg_fn, args, alias)
```

The PR adds similar code for datetime functions.


## Node Representation

In hyrise, every expression object is effectively represented by the same class. The `AbstractExpression` class has a field `_type` which functions as a tag and used for dispatch throughout the codebase. It also has an optional slot for every possible value an expression might use. Simplified depiction:

```python
class Expression:
    # tag to identify "subtype"
    type: ExpressionType

    # expression is literal
    value: Option<Value>

    # expression is a binary operation (e.g. plus)
    left: Option<Expression>
    right: Option<Expression>

    # expresion is a function
    function_args: Vec<Expression>

# 1 + 2
Expression(type=ExpressionType::Plus,
    left=Expression(type=ExpressionType::Literal, value=1),
    right=Expression(type=ExpressionType::Literal, value=2),
)
```


The `enum class ExpressionType` lists all possible types, including a `Function` variant. However, `ExpressionType::Function` specifically implies aggregate function throughout the code and not any function.

There is a further enum called `AggregateFunction` which lists all supported aggregate functions and is used as a secondary dispatch in `AbstractExpression`:

```cpp
enum class AggregateFunction { Min, Max, Sum, Avg, Count, CountDistinct };
```

#### Adding DateTime functions

The PR adds datetime function support to `AbstractExpression` similarly to aggregate functions:

* ExpressionType is extended by a new variant `DatetimeFunction`
* new ``enum class DatetimeFunction { Year, Month, Day }``
* new field in Expression for secondary dispatch for DatetimeFunction
* field for aggregate function arguments is reused
* added getter/creater and `to_string` and `==` support in AbstractExpression


## LQP to PQP

Since LQP and PQP are very similar, constructing a PQP node out of a LQP node is simple. The corresponding fields just have to be [copied](https://github.com/krichly/hyrise/pull/1/files#diff-dd51b376401d73b5ca9086a6bd6bae28R29).

## Operator Evaluation

Evaluating the datetime functions is [relatively straightforward](https://github.com/krichly/hyrise/pull/1/files#diff-1c7366f4698863ea6810218022d9b5cdR203).

Note: for the moment we only implement these functions on `long` fields.

# Discussion

## Custom Datatypes

The added functions only operate on integer columns. The column is interpreted as a unix timestamp, but it is desireable to have custom datatypes for date/datetime columns.

## Function Framework

It would certainly better to have a prescribed way to add new functions to hyrise and then add datetime functions in that fashion.

## Limitations

* The functions only work on columns but not other values (e.g. literals).
